### PR TITLE
Misc fixes, additional color actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(colorpick)
 cmake_minimum_required(VERSION 3.0)
+project(colorpick)
 
 set(APP_NAME ${PROJECT_NAME})
 

--- a/src/coloreditor.cpp
+++ b/src/coloreditor.cpp
@@ -171,7 +171,7 @@ void ColorEditor::fillCopyMenu()
     };
 
     auto addColorAction = [this](const QString &text, const QString &value) {
-        QString fullText = ColorEditor::tr("%1: %2").arg(text).arg(value);
+        QString fullText = ColorEditor::tr("%1: %2").arg(text, value);
         QAction *action = mCopyMenu->addAction(fullText);
         connect(action, &QAction::triggered, this, [value]() {
             QApplication::clipboard()->setText(value);
@@ -181,5 +181,7 @@ void ColorEditor::fillCopyMenu()
     addColorAction(tr("Inkscape"), hex(r) + hex(g) + hex(b) + hex(255));
     addColorAction(tr("Hexa with #"), "#" + hex(r) + hex(g) + hex(b));
     addColorAction(tr("Quoted hexa with #"), "\"#" + hex(r) + hex(g) + hex(b) + "\"");
-    addColorAction(tr("Float values"), QString("%1, %2, %3").arg(myfloat(rf)).arg(myfloat(gf)).arg(myfloat(bf)));
+    addColorAction(tr("Float values"), QString("%1, %2, %3").arg(myfloat(rf), myfloat(gf), myfloat(bf)));
+    addColorAction(tr("Int values"), QString("%1, %2, %3").arg(r).arg(g).arg(b));
+    addColorAction(tr("CSS RGB Value"), QString("rgb(%1, %2, %3)").arg(r).arg(g).arg(b));
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -17,7 +17,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     mFgEditor = new ColorEditor(QIcon::fromTheme("format-text-color"));
     mFgEditor->setAutoFillBackground(true);
     QPalette pal = palette();
-    pal.setColor(QPalette::Window, pal.color(QPalette::Window).dark(110));
+    pal.setColor(QPalette::Window, pal.color(QPalette::Window).darker(110));
     mFgEditor->setPalette(pal);
 
     ContrastPreview *preview = new ContrastPreview;


### PR DESCRIPTION
- Fix an error in CMake where project should follow cmake_minimum_required
- Apply the changes proposed in #2 by @ghost
- Fix some [other warnings about QString args](https://github.com/KDE/clazy/blob/1.11/docs/checks/README-qstring-arg.md)

I forgot to specify in the commit that I also added an additional color action: CSS RGB value and renamed the one by ghost to "Int values".

NOTE: the last 2 color actions doesn't use the `.arg(r, g, b)` form; for some reason it doesn't work here.

Fixes #2

![colorpick-copy](https://user-images.githubusercontent.com/1171962/231090133-7cddd028-68d2-47bf-aa3f-8c23a31b1498.png)