### PR TITLE
1 - HiDPI support

### DIFF
--- a/src/colorpicker.cpp
+++ b/src/colorpicker.cpp
@@ -17,11 +17,22 @@ static constexpr int GRAB_RADIUS = 16;
 static constexpr int GRAB_SIZE = GRAB_RADIUS * 2 + 1;
 static constexpr int MAGNIFY = 4;
 
+static qreal scaleFactor()
+{
+    QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
+    if (screen) {
+        return screen->devicePixelRatio();
+    }
+    return 1.0;
+}
+
 ColorPicker::ColorPicker()
 {
     setWindowFlags(Qt::Window | Qt::X11BypassWindowManagerHint);
     setAttribute(Qt::WA_DeleteOnClose);
     setFixedSize(GRAB_SIZE * MAGNIFY, GRAB_SIZE * MAGNIFY);
+
+    mScaleFactor = scaleFactor();
 
     mTimer = new QTimer(this);
     mTimer->setInterval(10);
@@ -83,7 +94,8 @@ void ColorPicker::keyPressEvent(QKeyEvent *event)
 void ColorPicker::paintEvent(QPaintEvent *event)
 {
     QPainter painter(this);
-    QPixmap pix = mPixmap.scaled(GRAB_SIZE * MAGNIFY, GRAB_SIZE * MAGNIFY);
+    QPixmap pix = mPixmap.scaled(GRAB_SIZE * mScaleFactor * MAGNIFY,
+                                 GRAB_SIZE * mScaleFactor * MAGNIFY);
     painter.drawPixmap(0, 0, pix);
 
     painter.setPen(Qt::darkGray);
@@ -102,24 +114,14 @@ void ColorPicker::paintEvent(QPaintEvent *event)
 void ColorPicker::emitColorChanged()
 {
     QImage image = mPixmap.toImage();
-    QColor color = QColor(image.pixel(GRAB_RADIUS, GRAB_RADIUS));
+    QColor color = image.pixelColor(GRAB_RADIUS * mScaleFactor, GRAB_RADIUS * mScaleFactor);
     colorChanged(color);
-}
-
-static QScreen *findScreenAt(const QPoint &pos)
-{
-    for (QScreen *screen : QGuiApplication::screens()) {
-        if (screen->geometry().contains(pos)) {
-            return screen;
-        }
-    }
-    return nullptr;
 }
 
 void ColorPicker::updatePosition()
 {
     QPoint pos = QCursor::pos();
-    QScreen *screen = findScreenAt(pos);
+    QScreen *screen = QGuiApplication::screenAt(pos);
     if (!screen) {
         qWarning() << "Could not find a screen containing" << pos;
         return;
@@ -141,6 +143,7 @@ void ColorPicker::updatePosition()
     move(newPos);
 
     WId wid = QApplication::desktop()->winId();
+
     mPixmap = screen->grabWindow(wid, pos.x() - GRAB_SIZE / 2, pos.y() - GRAB_SIZE / 2, GRAB_SIZE, GRAB_SIZE);
     update();
 }

--- a/src/colorpicker.h
+++ b/src/colorpicker.h
@@ -27,6 +27,7 @@ private:
 
     QTimer *mTimer;
     QPixmap mPixmap;
+    qreal mScaleFactor;
 };
 
 #endif // COLORPICKER_H


### PR DESCRIPTION
I omitted something like
```cpp
// default from Qt6, see https://bugreports.qt.io/browse/QTBUG-89279
#if QT_VERSION < 0x060000
  QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
#endif
```
(or `AA_EnableHighDpiScaling`) because it seems even without them HiDPI works anyway, at least on my Arch system (Qt 5.15.10), so I'm not sure if needed.

You can test these changes by running something like `QT_SCALE_FACTOR=1.25 qtcreator` from the terminal.

Fixes #5.
