### PR TITLE
Added ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+build*/
 .*.swp
 *.pyc
 ui_*.py
-build
 CMakeLists.txt.user
+compile_commands.json


### PR DESCRIPTION
- Extended the build directory to match others (E.g.: I use build for manual builds and buildqtc with QtCreator)
- Diff and patch files for WIP changes
- bak files are mainly for translations backups; using lupdate sometimes some strings are lost if using the wrong parameters
- json when generating compile_commands.json